### PR TITLE
Fix height units for footer icons

### DIFF
--- a/public_html/fingerboarding/fingerboarding.html
+++ b/public_html/fingerboarding/fingerboarding.html
@@ -31,7 +31,7 @@
       <a rel="me" href="https://social.tchncs.de/@Soundsphere" target="_blank">
       <img src="/mastodon.png" alt="mastodon icon" style="width:18px;height:18px;"></a>
       <a href="https://www.instagram.com/soundsphere/" target="_blank">
-      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18;"></a>
+      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18px;"></a>
     </p>
   </div>
 </div>

--- a/public_html/fingerboarding/spots/asiberlinshop.html
+++ b/public_html/fingerboarding/spots/asiberlinshop.html
@@ -28,7 +28,7 @@
       <a rel="me" href="https://social.tchncs.de/@Soundsphere" target="_blank">
       <img src="/mastodon.png" alt="mastodon icon" style="width:18px;height:18px;"></a>
       <a href="https://www.instagram.com/soundsphere/" target="_blank">
-      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18;"></a>
+      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18px;"></a>
     </p>
   </div>
 </div>

--- a/public_html/fingerboarding/spots/bloecke.html
+++ b/public_html/fingerboarding/spots/bloecke.html
@@ -29,7 +29,7 @@
       <a rel="me" href="https://social.tchncs.de/@Soundsphere" target="_blank">
       <img src="/mastodon.png" alt="mastodon icon" style="width:18px;height:18px;"></a>
       <a href="https://www.instagram.com/soundsphere/" target="_blank">
-      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18;"></a>
+      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18px;"></a>
     </p>
   </div>
 </div>

--- a/public_html/fingerboarding/spots/fingerboardspots.html
+++ b/public_html/fingerboarding/spots/fingerboardspots.html
@@ -39,7 +39,7 @@
       <a rel="me" href="https://social.tchncs.de/@Soundsphere" target="_blank">
       <img src="/mastodon.png" alt="mastodon icon" style="width:18px;height:18px;"></a>
       <a href="https://www.instagram.com/soundsphere/" target="_blank">
-      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18;"></a>
+      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18px;"></a>
     </p>
   </div>
 </div>

--- a/public_html/fingerboarding/spots/quarterart.html
+++ b/public_html/fingerboarding/spots/quarterart.html
@@ -51,7 +51,7 @@
       <a rel="me" href="https://social.tchncs.de/@Soundsphere" target="_blank">
       <img src="/mastodon.png" alt="mastodon icon" style="width:18px;height:18px;"></a>
       <a href="https://www.instagram.com/soundsphere/" target="_blank">
-      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18;"></a>
+      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18px;"></a>
     </p>
   </div>
 </div>

--- a/public_html/fingerboarding/spots/roundbankart.html
+++ b/public_html/fingerboarding/spots/roundbankart.html
@@ -49,7 +49,7 @@
       <a rel="me" href="https://social.tchncs.de/@Soundsphere" target="_blank">
       <img src="/mastodon.png" alt="mastodon icon" style="width:18px;height:18px;"></a>
       <a href="https://www.instagram.com/soundsphere/" target="_blank">
-      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18;"></a>
+      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18px;"></a>
     </p>
   </div>
 </div>

--- a/public_html/fingerboarding/spots/seatingbowls.html
+++ b/public_html/fingerboarding/spots/seatingbowls.html
@@ -53,7 +53,7 @@
       <a rel="me" href="https://social.tchncs.de/@Soundsphere" target="_blank">
       <img src="/mastodon.png" alt="mastodon icon" style="width:18px;height:18px;"></a>
       <a href="https://www.instagram.com/soundsphere/" target="_blank">
-      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18;"></a>
+      <img src="/instagram.png" alt="instagram icon" style="width:18px;height:18px;"></a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- update style for Instagram icons so height uses `px`

## Testing
- `grep -R "height:18;" -n public_html`

------
https://chatgpt.com/codex/tasks/task_e_6846f27fdbec832686a0db603978dae3