### PR TITLE
Add table search functionality

### DIFF
--- a/public_html/HTML/cds.html
+++ b/public_html/HTML/cds.html
@@ -23,8 +23,9 @@
   $sql = "SELECT Artist, Album FROM Stuff.CDs ORDER BY Artist, AlbumRelease ASC";
   $result = db_query($con, $sql);
 
-  echo "<table>
-        <thead>  
+  echo "<input type='text' class='table-search' onkeyup=\"filterTable('cdsTable', this.value)\">\n";
+  echo "<table id='cdsTable'>
+        <thead>
           <tr>
             <th>Number</th>
             <th>Artist</th>
@@ -50,5 +51,6 @@
 <?php include "../Static/footer.php"; ?>
 
 <script src="/Static/sort.js"></script>
+<script src="/Static/search.js"></script>
 </body>
 </html>

--- a/public_html/HTML/cdsfull.html
+++ b/public_html/HTML/cdsfull.html
@@ -24,7 +24,8 @@
   $sql = "SELECT Artist, Album, Tracks, Genre, Label, Type, Package, Discs, AlbumRelease, CDRelease, Country, Comment, Created FROM Stuff.CDs ORDER BY Artist, AlbumRelease ASC";
   $result = db_query($con, $sql);
 
-  echo "<table>
+  echo "<input type='text' class='table-search' onkeyup=\"filterTable('cdsFullTable', this.value)\">\n";
+  echo "<table id='cdsFullTable'>
         <thead>
           <tr>
             <th>Number</th>
@@ -73,5 +74,6 @@
 <?php include "../Static/footer.php"; ?>
 
 <script src="/Static/sort.js"></script>
+<script src="/Static/search.js"></script>
 </body>
 </html>

--- a/public_html/HTML/modular.html
+++ b/public_html/HTML/modular.html
@@ -25,8 +25,9 @@
     $con = db_connect();
     $sql = "SELECT Manufacturer, Model, Type, Width, Depth, p12v, n12v FROM Stuff.Modules ORDER BY Manufacturer ASC";
     $result = db_query($con, $sql);
-  
-    echo "<table>
+
+    echo "<input type='text' class='table-search' onkeyup=\"filterTable('modularTable', this.value)\">\n";
+    echo "<table id='modularTable'>
           <thead>
             <tr>
               <th>Number</th>
@@ -91,5 +92,6 @@
 <?php include "../Static/footer.php"; ?>
 
 <script src="/Static/sort.js"></script>
+<script src="/Static/search.js"></script>
 </body>
 </html>

--- a/public_html/HTML/waffeleisen.html
+++ b/public_html/HTML/waffeleisen.html
@@ -23,7 +23,8 @@
   $sql = "SELECT Artist, Album FROM Stuff.CDs ORDER BY Artist, AlbumRelease ASC";
   $result = db_query($con, $sql);
 
-  echo "<table>
+  echo "<input type='text' class='table-search' onkeyup=\"filterTable('waffleTable', this.value)\">\n";
+  echo "<table id='waffleTable'>
   <tr>
   <th>Number</th>
   <th>Artist</th>
@@ -46,5 +47,6 @@
 
 <?php include "../Static/footer.php"; ?>
 
+<script src="/Static/search.js"></script>
 </body>
 </html>

--- a/public_html/Static/search.js
+++ b/public_html/Static/search.js
@@ -1,0 +1,8 @@
+function filterTable(tableId, query) {
+    const filter = query.toLowerCase();
+    const rows = document.querySelectorAll(`#${tableId} tbody tr`);
+    rows.forEach(row => {
+        const text = row.textContent.toLowerCase();
+        row.style.display = text.includes(filter) ? '' : 'none';
+    });
+}

--- a/public_html/Style/style.css
+++ b/public_html/Style/style.css
@@ -119,3 +119,11 @@ div.smimages {
 /* sort icons for tables */
 th.sort-asc::after  { content: ' ▲'; }
 th.sort-desc::after { content: ' ▼'; }
+
+/* basic search input styling */
+input.table-search {
+  margin-bottom: 10px;
+  padding: 5px;
+  max-width: 300px;
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- add simple client-side table search script
- hook up search boxes on each table page
- style the search inputs

## Testing
- `php -l public_html/HTML/cds.html` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68477081c32083268a2729878a7bc650