### PR TITLE
Add label before table search inputs

### DIFF
--- a/public_html/HTML/cds.html
+++ b/public_html/HTML/cds.html
@@ -23,7 +23,7 @@
   $sql = "SELECT Artist, Album FROM Stuff.CDs ORDER BY Artist, AlbumRelease ASC";
   $result = db_query($con, $sql);
 
-  echo "<input type='text' class='table-search' onkeyup=\"filterTable('cdsTable', this.value)\">\n";
+  echo "Search: <input type='text' class='table-search' onkeyup=\"filterTable('cdsTable', this.value)\">\n";
   echo "<table id='cdsTable'>
         <thead>
           <tr>

--- a/public_html/HTML/cdsfull.html
+++ b/public_html/HTML/cdsfull.html
@@ -24,7 +24,7 @@
   $sql = "SELECT Artist, Album, Tracks, Genre, Label, Type, Package, Discs, AlbumRelease, CDRelease, Country, Comment, Created FROM Stuff.CDs ORDER BY Artist, AlbumRelease ASC";
   $result = db_query($con, $sql);
 
-  echo "<input type='text' class='table-search' onkeyup=\"filterTable('cdsFullTable', this.value)\">\n";
+  echo "Search: <input type='text' class='table-search' onkeyup=\"filterTable('cdsFullTable', this.value)\">\n";
   echo "<table id='cdsFullTable'>
         <thead>
           <tr>

--- a/public_html/HTML/modular.html
+++ b/public_html/HTML/modular.html
@@ -26,7 +26,7 @@
     $sql = "SELECT Manufacturer, Model, Type, Width, Depth, p12v, n12v FROM Stuff.Modules ORDER BY Manufacturer ASC";
     $result = db_query($con, $sql);
 
-    echo "<input type='text' class='table-search' onkeyup=\"filterTable('modularTable', this.value)\">\n";
+    echo "Search: <input type='text' class='table-search' onkeyup=\"filterTable('modularTable', this.value)\">\n";
     echo "<table id='modularTable'>
           <thead>
             <tr>

--- a/public_html/HTML/waffeleisen.html
+++ b/public_html/HTML/waffeleisen.html
@@ -23,7 +23,7 @@
   $sql = "SELECT Artist, Album FROM Stuff.CDs ORDER BY Artist, AlbumRelease ASC";
   $result = db_query($con, $sql);
 
-  echo "<input type='text' class='table-search' onkeyup=\"filterTable('waffleTable', this.value)\">\n";
+  echo "Search: <input type='text' class='table-search' onkeyup=\"filterTable('waffleTable', this.value)\">\n";
   echo "<table id='waffleTable'>
   <tr>
   <th>Number</th>


### PR DESCRIPTION
## Summary
- show the text `Search:` before each table search input

## Testing
- `pytest -q` *(fails: no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_684843368a54832683e72175effe1a44