### PR TITLE
Fix hover color for top navigation

### DIFF
--- a/public_html/Style/style.css
+++ b/public_html/Style/style.css
@@ -36,7 +36,7 @@ div.topnav a {
 /* Change color on hover */
 div.topnav a:hover {
   background-color: #6b5b95;
-  color: black;
+  color: white;
 }
 
 /* Style the content */

--- a/public_html/fingerboarding/fstyle.css
+++ b/public_html/fingerboarding/fstyle.css
@@ -36,7 +36,7 @@ div.topnav a {
 /* Change color on hover */
 div.topnav a:hover {
   background-color: #6b5b95;
-  color: black;
+  color: white;
 }
 
 /* Style the content */


### PR DESCRIPTION
## Summary
- keep text white on hover in the global stylesheet
- keep text white on hover in fingerboarding stylesheet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848387f5f548326a26943ac3e99dea2