### PR TITLE
Add robots.txt to prevent indexing

### DIFF
--- a/public_html/robots.txt
+++ b/public_html/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary
- add a `robots.txt` under `public_html` to disallow web crawlers from indexing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684938875bd083269b644091f2041b64