### PR TITLE
Add responsive style for modular grid image

### DIFF
--- a/public_html/Style/style.css
+++ b/public_html/Style/style.css
@@ -143,3 +143,16 @@ div.Videos iframe {
   width: 50%;
   aspect-ratio: 16/9;
 }
+
+/* styling for the modular grid image */
+div.image {
+  text-align: center;
+}
+
+div.image img {
+  width: 100%;
+  height: auto;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}


### PR DESCRIPTION
## Summary
- center the modular rig image and make it scale to the full width of its container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68498e8e7fb8832698de5cb704ffb65a