### PR TITLE
Enable PHP in fingerboarding section

### DIFF
--- a/public_html/fingerboarding/.htaccess
+++ b/public_html/fingerboarding/.htaccess
@@ -1,0 +1,8 @@
+FcgidWrapper "/home/httpd/cgi-bin/php74-fcgi-starter.fcgi" .php
+FcgidWrapper "/home/httpd/cgi-bin/php71-fcgi-starter.fcgi" .html
+FcgidWrapper "/home/httpd/cgi-bin/php71-fcgi-starter.fcgi" .htm
+<FilesMatch "\.(html|htm)$">
+ SetHandler fcgid-script
+</FilesMatch>
+php_flag  log_errors on
+php_value error_log  /usr/home/«login»/php.log

--- a/public_html/fingerboarding/spots/asiberlinshop.html
+++ b/public_html/fingerboarding/spots/asiberlinshop.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<?php include "../Static/header.php"; ?>
+<?php include "../../Static/header.php"; ?>
 
 <div class="content">
 <h1>Asi Berlin Shop</h1>
@@ -19,7 +19,7 @@
 </br>
   <p><iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://www.openstreetmap.org/export/embed.html?bbox=13.451573252677917%2C52.512651047461446%2C13.457769155502321%2C52.514717560931494&amp;layer=mapnik&amp;marker=52.51368431634428%2C13.454671204090118" style="border: 1px solid black"></iframe></p>
 
-<?php include "../Static/footer.php"; ?>
+<?php include "../../Static/footer.php"; ?>
 
 </body>
 </html>

--- a/public_html/fingerboarding/spots/bloecke.html
+++ b/public_html/fingerboarding/spots/bloecke.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<?php include "../Static/header.php"; ?>
+<?php include "../../Static/header.php"; ?>
 
 <div class="content">
 <h1>Blöcke</h1>
@@ -20,7 +20,7 @@
   <p><iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://www.openstreetmap.org/export/embed.html?bbox=13.40810537338257%2C52.53828787043689%2C13.414301276206972%2C52.54035317809827&amp;layer=mapnik&amp;marker=52.539320536412454%2C13.41120332479477" style="border: 1px solid black"></iframe></p>
 </div>
 
-<?php include "../Static/footer.php"; ?>
+<?php include "../../Static/footer.php"; ?>
 
 </body>
 </html>

--- a/public_html/fingerboarding/spots/fingerboardspots.html
+++ b/public_html/fingerboarding/spots/fingerboardspots.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<?php include "../Static/header.php"; ?>
+<?php include "../../Static/header.php"; ?>
 
 <div class="content">
 <h1>Fingerboard Spots</h1>
@@ -30,7 +30,7 @@
   <br/>
 </div>
 
-<?php include "../Static/footer.php"; ?>
+<?php include "../../Static/footer.php"; ?>
 
 </body>
 </html>

--- a/public_html/fingerboarding/spots/quarterart.html
+++ b/public_html/fingerboarding/spots/quarterart.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<?php include "../Static/header.php"; ?>
+<?php include "../../Static/header.php"; ?>
 
 <a name="top"></a>
 <div class="content">
@@ -43,7 +43,7 @@
 </div>
 </div>
 
-<?php include "../Static/footer.php"; ?>
+<?php include "../../Static/footer.php"; ?>
 
 </body>
 </html>

--- a/public_html/fingerboarding/spots/roundbankart.html
+++ b/public_html/fingerboarding/spots/roundbankart.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<?php include "../Static/header.php"; ?>
+<?php include "../../Static/header.php"; ?>
 
 <a name="top"></a>
 <div class="content">
@@ -41,7 +41,7 @@
 </div>
 </div>
 
-<?php include "../Static/footer.php"; ?>
+<?php include "../../Static/footer.php"; ?>
 
 </body>
 </html>

--- a/public_html/fingerboarding/spots/seatingbowls.html
+++ b/public_html/fingerboarding/spots/seatingbowls.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<?php include "../Static/header.php"; ?>
+<?php include "../../Static/header.php"; ?>
 
 <a name="top"></a>
 <div class="content">
@@ -45,7 +45,7 @@
 </div>
 </div>
 
-<?php include "../Static/footer.php"; ?>
+<?php include "../../Static/footer.php"; ?>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow PHP execution for fingerboarding pages by copying the PHP handler `.htaccess`
- fix header/footer includes in all fingerboarding spot pages so they reference `../../Static`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68499601c5148326a3a6cf73d27bda08