### PR TITLE
Fix footer icon spacing

### DIFF
--- a/public_html/Style/style.css
+++ b/public_html/Style/style.css
@@ -113,7 +113,15 @@ div.footer {
 div.smimages {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  height: 100%;
   padding-right: 20px;
+  gap: 10px;
+}
+
+div.smimages p {
+  margin: 0;
+  line-height: 0;
 }
 
 /* sort icons for tables */


### PR DESCRIPTION
## Summary
- center footer icons vertically
- increase spacing between Mastodon and Instagram icons

## Testing
- `php -l public_html/HTML/config_share.php public_html/HTML/db.php public_html/Static/header.php public_html/Static/footer.php public_html/index.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a879a2208326ac1cd04efa209290