### PR TITLE
Fix link line height

### DIFF
--- a/public_html/Style/style.css
+++ b/public_html/Style/style.css
@@ -55,6 +55,7 @@ div.content {
 div.content a {
   color: #886FC6;
   text-decoration: none;
+  line-height: inherit;
 }
 
 div.content a:hover {


### PR DESCRIPTION
## Summary
- make links inside `.content` inherit line height so their height matches surrounding text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c9835168c8326a539c8bbbb14e249