### PR TITLE
Add nested spot list to fingerboarding page

### DIFF
--- a/public_html/fingerboarding/fingerboarding.html
+++ b/public_html/fingerboarding/fingerboarding.html
@@ -26,10 +26,9 @@
   </p>
   <br/>
   <div class="spotlist">
+    <h3>Berlin</h3>
     <ul>
-      <li>Berlin
-        <ul>
-          <li>Mitte
+      <li>Mitte
             <ul>
               <li><a href="spots/seatingbowls.html">Seating Bowls</a></li>
               <li><a href="spots/loewendenkmal.html">Löwendenkmal WIP</a></li>
@@ -45,8 +44,6 @@
               <li><a href="spots/roundbankart.html">Rounded Bank Art</a></li>
             </ul>
           </li>
-        </ul>
-      </li>
     </ul>
   </div>
   <br/>

--- a/public_html/fingerboarding/fingerboarding.html
+++ b/public_html/fingerboarding/fingerboarding.html
@@ -26,20 +26,28 @@
   </p>
   <br/>
   <div class="spotlist">
-      <h2>Berlin</h2>
-          <h3>Mitte</h3>
+    <ul>
+      <li>Berlin
+        <ul>
+          <li>Mitte
             <ul>
               <li><a href="spots/seatingbowls.html">Seating Bowls</a></li>
               <li><a href="spots/loewendenkmal.html">Löwendenkmal WIP</a></li>
             </ul>
-          <h3>Friedrichshain</h3>
+          </li>
+          <li>Friedrichshain
             <ul>
               <li><a href="spots/asiberlinshop.html">ASI Berlin Store</a></li>
             </ul>
-          <h3>Marzahn</h3>
+          </li>
+          <li>Marzahn
             <ul>
               <li><a href="spots/roundbankart.html">Rounded Bank Art</a></li>
-          </ul>
+            </ul>
+          </li>
+        </ul>
+      </li>
+    </ul>
   </div>
   <br/>
 </div>


### PR DESCRIPTION
## Summary
- display Berlin fingerboard spots in a nested list

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684cb85de9f4832698b707ee6400c0f2