### PR TITLE
Fix Safari tab bar color

### DIFF
--- a/public_html/HTML/cds.html
+++ b/public_html/HTML/cds.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#7866ae">
+<meta name="theme-color" content="#886FC6">
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 </head>

--- a/public_html/HTML/cdsfull.html
+++ b/public_html/HTML/cdsfull.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#7866ae">
+<meta name="theme-color" content="#886FC6">
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 </head>

--- a/public_html/HTML/modular.html
+++ b/public_html/HTML/modular.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#7866ae">
+<meta name="theme-color" content="#886FC6">
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 </head>

--- a/public_html/HTML/waffeleisen.html
+++ b/public_html/HTML/waffeleisen.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#7866ae">
+<meta name="theme-color" content="#886FC6">
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 </head>

--- a/public_html/fingerboarding/fingerboarding.html
+++ b/public_html/fingerboarding/fingerboarding.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#7866ae">
+<meta name="theme-color" content="#886FC6">
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 </head>

--- a/public_html/fingerboarding/spots/asiberlinshop.html
+++ b/public_html/fingerboarding/spots/asiberlinshop.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#7866ae">
+<meta name="theme-color" content="#886FC6">
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 </head>

--- a/public_html/fingerboarding/spots/bloecke.html
+++ b/public_html/fingerboarding/spots/bloecke.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#7866ae">
+<meta name="theme-color" content="#886FC6">
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 </head>

--- a/public_html/fingerboarding/spots/loewendenkmal.html
+++ b/public_html/fingerboarding/spots/loewendenkmal.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#7866ae">
+<meta name="theme-color" content="#886FC6">
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 </head>

--- a/public_html/fingerboarding/spots/roundbankart.html
+++ b/public_html/fingerboarding/spots/roundbankart.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#7866ae">
+<meta name="theme-color" content="#886FC6">
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 </head>

--- a/public_html/fingerboarding/spots/seatingbowls.html
+++ b/public_html/fingerboarding/spots/seatingbowls.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#7866ae">
+<meta name="theme-color" content="#886FC6">
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 </head>

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<meta name="theme-color" content="#7866ae">
+<meta name="theme-color" content="#886FC6">
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 </head>


### PR DESCRIPTION
## Summary
- update theme-color meta tag on every page so Safari tab bar matches header background

## Testing
- `grep -R "theme-color" -n public_html`

------
https://chatgpt.com/codex/tasks/task_e_684cbea955908326b4216d7b836823dc