### PR TITLE
Enable PHP for iRacing page

### DIFF
--- a/public_html/iracing/.htaccess
+++ b/public_html/iracing/.htaccess
@@ -1,0 +1,8 @@
+FcgidWrapper "/home/httpd/cgi-bin/php74-fcgi-starter.fcgi" .php
+FcgidWrapper "/home/httpd/cgi-bin/php71-fcgi-starter.fcgi" .html
+FcgidWrapper "/home/httpd/cgi-bin/php71-fcgi-starter.fcgi" .htm
+<FilesMatch "\.(html|htm)$">
+ SetHandler fcgid-script
+</FilesMatch>
+php_flag  log_errors on
+php_value error_log  /usr/home/«login»/php.log


### PR DESCRIPTION
## Summary
- allow running PHP inside `iracing.html` by adding an `.htaccess` file

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f256887d483269855dd851d6b23c0