### PR TITLE
Add iRacing rating summary table

### DIFF
--- a/public_html/Static/sort.js
+++ b/public_html/Static/sort.js
@@ -27,6 +27,10 @@ function sortTable(table, column, asc = true) {
 
 window.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('table').forEach(table => {
+        // Skip tables marked with the 'no-sort' class
+        if (table.classList.contains('no-sort')) {
+            return;
+        }
         table.querySelectorAll('th').forEach((th, index) => {
             th.addEventListener('click', () => {
                 const asc = !th.classList.contains('sort-asc');

--- a/public_html/iracing/iracing.html
+++ b/public_html/iracing/iracing.html
@@ -9,7 +9,8 @@
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 <style>
-  /* Disable automatic row numbering for this table */
+  /* Disable automatic row numbering for rating and race tables */
+  #ratingSummary tr td:first-child::before,
   #iRacingTable tr td:first-child::before {
     content: none;
   }
@@ -26,6 +27,38 @@
   <?php
   require_once __DIR__ . '/../HTML/db.php';
   $con = db_connect();
+
+  $raceTypes = [
+    'Oval' => 'ovalcarrating.html',
+    'Formula Car' => 'formulacarrating.html',
+    'Sports Car' => 'sportscarrating.html',
+    'Dirt Oval' => 'dirtoval.html',
+    'Dirt Road' => 'dirtroad.html'
+  ];
+  $ratings = [];
+  foreach ($raceTypes as $type => $link) {
+    $ratingSql = "SELECT NewiRating, NewSafetyRating FROM Stuff.iRacing WHERE RaceType = '$type' ORDER BY SessionDate DESC LIMIT 1";
+    $ratingResult = db_query($con, $ratingSql);
+    $ratings[$type] = mysqli_fetch_assoc($ratingResult);
+  }
+
+  echo "<table id='ratingSummary'>\n<thead><tr>";
+  foreach ($raceTypes as $type => $link) {
+    $safeLink = htmlspecialchars($link);
+    echo "<th><a href='$safeLink'>$type</a></th>";
+  }
+  echo "</tr></thead><tbody><tr>";
+  foreach ($raceTypes as $type => $link) {
+    if ($ratings[$type]) {
+      $ir = htmlspecialchars($ratings[$type]['NewiRating']);
+      $sr = htmlspecialchars($ratings[$type]['NewSafetyRating']);
+      $display = "$ir | $sr";
+    } else {
+      $display = 'N/A';
+    }
+    echo "<td>$display</td>";
+  }
+  echo "</tr></tbody></table>\n<br><br>\n";
 
   $sql = "SELECT SessionDate, SeriesName, Track, Car, QualifyingTime, RaceTime, StartPosition, FinishPosition, Laps, Incidents, SafetyRatingGain, iRatingGain, SoF, Points, TeamRace,  QualiSetByTeammate, FastestLapSetByTeammate FROM Stuff.iRacing ORDER BY SessionDate DESC";
   $result = db_query($con, $sql);

--- a/public_html/iracing/iracing.html
+++ b/public_html/iracing/iracing.html
@@ -61,13 +61,13 @@
   }
   echo "</tr></thead><tbody><tr>";
   foreach ($raceTypes as $type => $link) {
-    $display = '-';
+    $display = 'no races';
     if ($ratings[$type]) {
       $irVal = $ratings[$type]['NewiRating'];
       $srVal = $ratings[$type]['NewSafetyRating'];
       if (!empty($irVal) && $irVal != 0 && !empty($srVal) && $srVal != 0) {
-        $ir = 'iRating ' . htmlspecialchars($irVal);
-        $sr = 'Safety Rating ' . htmlspecialchars($srVal);
+        $ir = 'iRating: ' . htmlspecialchars($irVal);
+        $sr = 'Safety Rating: ' . htmlspecialchars($srVal);
         $display = "$ir | $sr";
       }
     }

--- a/public_html/iracing/iracing.html
+++ b/public_html/iracing/iracing.html
@@ -15,6 +15,12 @@
     content: none;
   }
 
+  /* layout for rating summary table */
+  #ratingSummary {
+    width: 60%;
+    margin: 0 auto;
+  }
+
   /* centre the rating summary values */
   #ratingSummary th,
   #ratingSummary td {

--- a/public_html/iracing/iracing.html
+++ b/public_html/iracing/iracing.html
@@ -48,7 +48,7 @@
     $ratings[$type] = mysqli_fetch_assoc($ratingResult);
   }
 
-  echo "<table id='ratingSummary'>\n<thead><tr>";
+  echo "<table id='ratingSummary' class='no-sort'>\n<thead><tr>";
   foreach ($raceTypes as $type => $link) {
     $safeLink = htmlspecialchars($link);
     echo "<th><a href='$safeLink'>$type</a></th>";

--- a/public_html/iracing/iracing.html
+++ b/public_html/iracing/iracing.html
@@ -14,6 +14,12 @@
   #iRacingTable tr td:first-child::before {
     content: none;
   }
+
+  /* centre the rating summary values */
+  #ratingSummary th,
+  #ratingSummary td {
+    text-align: center;
+  }
 </style>
 </head>
 <body>
@@ -49,12 +55,15 @@
   }
   echo "</tr></thead><tbody><tr>";
   foreach ($raceTypes as $type => $link) {
+    $display = '-';
     if ($ratings[$type]) {
-      $ir = htmlspecialchars($ratings[$type]['NewiRating']);
-      $sr = htmlspecialchars($ratings[$type]['NewSafetyRating']);
-      $display = "$ir | $sr";
-    } else {
-      $display = 'N/A';
+      $irVal = $ratings[$type]['NewiRating'];
+      $srVal = $ratings[$type]['NewSafetyRating'];
+      if (!empty($irVal) && $irVal != 0 && !empty($srVal) && $srVal != 0) {
+        $ir = 'iRating ' . htmlspecialchars($irVal);
+        $sr = 'Safety Rating ' . htmlspecialchars($srVal);
+        $display = "$ir | $sr";
+      }
     }
     echo "<td>$display</td>";
   }


### PR DESCRIPTION
## Summary
- show latest ratings for each race type above the race table
- disable auto-row numbering for new table

## Testing
- `php -l public_html/iracing/iracing.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1f20c1c4832697d962dabee777dc