### PR TITLE
Remove sort icons

### DIFF
--- a/public_html/Style/style.css
+++ b/public_html/Style/style.css
@@ -134,9 +134,10 @@ div.smimages p {
   line-height: 0;
 }
 
-/* sort icons for tables */
-th.sort-asc::after  { content: ' ▲'; }
-th.sort-desc::after { content: ' ▼'; }
+/* sort icons for sortable tables only */
+table:not(.no-sort) th.sort-asc::after  { content: ' ▲'; }
+table:not(.no-sort) th.sort-desc::after { content: ' ▼'; }
+
 
 /* basic search input styling */
 input.table-search {


### PR DESCRIPTION
## Summary
- clean up table style by removing arrow icons
- restore icons for sortable tables only so racetype table is unaffected

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b2540cacc832697383602d7ae86f5