### PR TITLE
Highlight Sports Car header only on Sports Car page

### DIFF
--- a/public_html/Style/style.css
+++ b/public_html/Style/style.css
@@ -65,8 +65,13 @@ div.content a:hover {
 }
 
 /* highlight the Sports Car header in race type tables */
+th.sports-car {
+  background-color: #AE91F6;
+  color: white;
+}
+
 th.sports-car a {
-  color: #AE91F6;
+  color: white;
 }
 
 /* set table width and start the counter for the rows */

--- a/public_html/Style/style.css
+++ b/public_html/Style/style.css
@@ -64,6 +64,11 @@ div.content a:hover {
   text-decoration: none;
 }
 
+/* highlight the Sports Car header in race type tables */
+th.sports-car a {
+  color: #AE91F6;
+}
+
 /* set table width and start the counter for the rows */
 table {
   width: 100%;

--- a/public_html/iracing/sportscarrating.html
+++ b/public_html/iracing/sportscarrating.html
@@ -60,7 +60,8 @@
   echo "<table id='ratingSummary' class='no-sort'>\n<thead><tr>";
   foreach ($raceTypes as $type => $link) {
     $safeLink = htmlspecialchars($link);
-    echo "<th><a href='$safeLink'>$type</a></th>";
+    $thClass = ($type === 'Sports Car') ? " class='sports-car'" : '';
+    echo "<th$thClass><a href='$safeLink'>$type</a></th>";
   }
   echo "</tr></thead><tbody><tr>";
   foreach ($raceTypes as $type => $link) {


### PR DESCRIPTION
## Summary
- highlight the `Sports Car` header in rating tables via `.sports-car` class
- apply the class only on `sportscarrating.html`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2b645f988326b57930d0841d3955