### PR TITLE
Fix race rating header highlighting

### DIFF
--- a/public_html/Style/style.css
+++ b/public_html/Style/style.css
@@ -95,7 +95,7 @@ th.oval a {
 }
 
 /* highlight the Dirt Oval header in race type tables */
-th.dirt-Oval {
+th.dirt-oval {
   background-color: #AE91F6;
   color: white;
 }

--- a/public_html/iracing/dirtovalrating.html
+++ b/public_html/iracing/dirtovalrating.html
@@ -60,7 +60,7 @@
   foreach ($raceTypes as $type => $link) {
     $safeLink = htmlspecialchars($link);
     $thClass = ($type === 'Dirt Oval') ? " class='dirt-oval'" : '';
-    echo "<th><a href='$safeLink'>$type</a></th>";
+    echo "<th$thClass><a href='$safeLink'>$type</a></th>";
   }
   echo "</tr></thead><tbody><tr>";
   foreach ($raceTypes as $type => $link) {

--- a/public_html/iracing/dirtroadrating.html
+++ b/public_html/iracing/dirtroadrating.html
@@ -60,7 +60,7 @@
   foreach ($raceTypes as $type => $link) {
     $safeLink = htmlspecialchars($link);
     $thClass = ($type === 'Dirt Road') ? " class='dirt-road'" : '';
-    echo "<th><a href='$safeLink'>$type</a></th>";
+    echo "<th$thClass><a href='$safeLink'>$type</a></th>";
   }
   echo "</tr></thead><tbody><tr>";
   foreach ($raceTypes as $type => $link) {

--- a/public_html/iracing/formulacarrating.html
+++ b/public_html/iracing/formulacarrating.html
@@ -60,7 +60,7 @@
   foreach ($raceTypes as $type => $link) {
     $safeLink = htmlspecialchars($link);
     $thClass = ($type === 'Formula Car') ? " class='formula-car'" : '';
-    echo "<th><a href='$safeLink'>$type</a></th>";
+    echo "<th$thClass><a href='$safeLink'>$type</a></th>";
   }
   echo "</tr></thead><tbody><tr>";
   foreach ($raceTypes as $type => $link) {

--- a/public_html/iracing/ovalcarrating.html
+++ b/public_html/iracing/ovalcarrating.html
@@ -60,7 +60,7 @@
   foreach ($raceTypes as $type => $link) {
     $safeLink = htmlspecialchars($link);
     $thClass = ($type === 'Oval') ? " class='oval'" : '';
-    echo "<th><a href='$safeLink'>$type</a></th>";
+    echo "<th$thClass><a href='$safeLink'>$type</a></th>";
   }
   echo "</tr></thead><tbody><tr>";
   foreach ($raceTypes as $type => $link) {


### PR DESCRIPTION
## Summary
- ensure rating pages apply their highlight class
- correct CSS selector for dirt oval table headers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b311cdeac8326ac60f642d8ad1fb0