### PR TITLE
Add averages summary to iRacing page

### DIFF
--- a/public_html/iracing/iracing.html
+++ b/public_html/iracing/iracing.html
@@ -22,6 +22,12 @@
     margin: 0 auto;
   }
 
+  /* layout for averages table */
+  #averagesTable {
+    width: 80%;
+    margin: 0 auto;
+  }
+
   /* centre the rating summary values */
   #ratingSummary th,
   #ratingSummary td {

--- a/public_html/iracing/iracing.html
+++ b/public_html/iracing/iracing.html
@@ -74,9 +74,46 @@
   }
   echo "</tr></tbody></table>\n<br><br>\n";
 
+  // Query average statistics per race type
+  $avgSql = "SELECT COUNT(RaceType) AS RaceTypes, RaceType, ROUND(AVG(SoF),0) AS `Average SoF`, ROUND(AVG(NewiRating),0) AS `Average iRating`, ROUND(AVG(NewSafetyRating),2) AS `Average Safety Rating`, ROUND(AVG(Incidents),2) AS Incidents, ROUND(AVG(StartPosition),0) AS `Starting Position`, ROUND(AVG(FinishPosition),0) AS `Finish Position`, ROUND(AVG(Points),0) AS Points, SUM(LapsLed) AS `Laps Led`, SUM(Laps) AS `Laps Driven` FROM Stuff.iRacing GROUP BY RaceType ORDER BY COUNT(RaceType) DESC";
+  $avgResult = db_query($con, $avgSql);
+
+  echo "<h2>Averages</h2>\n";
+  echo "<table id='averagesTable' class='no-sort'>\n<thead><tr>";
+  echo "<th>Race Type</th>";
+  echo "<th>Races</th>";
+  echo "<th>Average SoF</th>";
+  echo "<th>Average iRating</th>";
+  echo "<th>Average Safety Rating</th>";
+  echo "<th>Incidents</th>";
+  echo "<th>Starting Position</th>";
+  echo "<th>Finish Position</th>";
+  echo "<th>Points</th>";
+  echo "<th>Laps Led</th>";
+  echo "<th>Laps Driven</th>";
+  echo "</tr></thead><tbody>";
+
+  while ($avgRow = mysqli_fetch_assoc($avgResult)) {
+    echo "<tr>";
+    echo "<td>" . htmlspecialchars($avgRow['RaceType']) . "</td>";
+    echo "<td>" . htmlspecialchars($avgRow['RaceTypes']) . "</td>";
+    echo "<td>" . htmlspecialchars($avgRow['Average SoF']) . "</td>";
+    echo "<td>" . htmlspecialchars($avgRow['Average iRating']) . "</td>";
+    echo "<td>" . htmlspecialchars($avgRow['Average Safety Rating']) . "</td>";
+    echo "<td>" . htmlspecialchars($avgRow['Incidents']) . "</td>";
+    echo "<td>" . htmlspecialchars($avgRow['Starting Position']) . "</td>";
+    echo "<td>" . htmlspecialchars($avgRow['Finish Position']) . "</td>";
+    echo "<td>" . htmlspecialchars($avgRow['Points']) . "</td>";
+    echo "<td>" . htmlspecialchars($avgRow['Laps Led']) . "</td>";
+    echo "<td>" . htmlspecialchars($avgRow['Laps Driven']) . "</td>";
+    echo "</tr>";
+  }
+  echo "</tbody></table>\n<br><br>\n";
+
   $sql = "SELECT SessionDate, SeriesName, Track, Car, QualifyingTime, RaceTime, StartPosition, FinishPosition, Laps, Incidents, SafetyRatingGain, iRatingGain, SoF, Points, TeamRace,  QualiSetByTeammate, FastestLapSetByTeammate FROM Stuff.iRacing ORDER BY SessionDate DESC";
   $result = db_query($con, $sql);
 
+  echo "<h2>Recent Races</h2>\n";
   echo "Search Races: <input type='text' class='table-search' onkeyup=\"filterTable('iRacingTable', this.value)\">\n";
   echo "<table id='iRacingTable'>
         <thead>

--- a/public_html/iracing/iracing.html
+++ b/public_html/iracing/iracing.html
@@ -9,8 +9,9 @@
 <link rel="stylesheet" href="/Style/style.css">
 <link rel="icon" type="image/png" href="/Static/favicon.png">
 <style>
-  /* Disable automatic row numbering for rating and race tables */
+  /* Disable automatic row numbering for rating, averages, and race tables */
   #ratingSummary tr td:first-child::before,
+  #averagesTable tr td:first-child::before,
   #iRacingTable tr td:first-child::before {
     content: none;
   }


### PR DESCRIPTION
## Summary
- query average race stats and show an "Averages" table
- add "Recent Races" header above races table

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686effa1e29c8326837eb7fddac26b3e